### PR TITLE
Refactor backend database handling and add tests

### DIFF
--- a/applications/backend/app/app.py
+++ b/applications/backend/app/app.py
@@ -1,7 +1,15 @@
-from flask import Flask, jsonify
-import mysql.connector
+import logging
 import os
+from contextlib import contextmanager
 from datetime import datetime
+from decimal import Decimal
+from typing import Any, Dict, Iterator
+
+import mysql.connector
+from flask import Flask, jsonify
+from mysql.connector import Error, pooling
+
+logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
@@ -14,21 +22,132 @@ def get_env_var(key: str) -> str:
     return value
 
 
-# Database config from environment variables (provided by Kubernetes Secrets)
-db_config = {
-    "host": get_env_var("MYSQL_HOST"),
-    "port": int(get_env_var("MYSQL_PORT")),
-    "user": get_env_var("MYSQL_USER"),
-    "password": get_env_var("MYSQL_PASSWORD"),
-    "database": get_env_var("MYSQL_DATABASE"),
-}
-
-
-def get_connection():
+def get_int_env_var(key: str, *, default: int | None = None) -> int:
+    """Fetch an environment variable expected to contain an integer."""
+    raw_value = os.getenv(key)
+    if raw_value in (None, ""):
+        if default is not None:
+            return default
+        raise RuntimeError(f"❌ Missing required environment variable: {key}")
     try:
-        return mysql.connector.connect(**db_config)
-    except mysql.connector.Error as e:
-        raise RuntimeError(f"❌ Database connection failed: {e}")
+        return int(raw_value)
+    except ValueError as exc:
+        raise RuntimeError(f"❌ Environment variable {key} must be an integer (got {raw_value!r})") from exc
+
+
+def load_db_config_from_env() -> Dict[str, Any]:
+    """Build the database configuration from environment variables."""
+    return {
+        "host": get_env_var("MYSQL_HOST"),
+        "port": get_int_env_var("MYSQL_PORT"),
+        "user": get_env_var("MYSQL_USER"),
+        "password": get_env_var("MYSQL_PASSWORD"),
+        "database": get_env_var("MYSQL_DATABASE"),
+        # Short connection timeout so readiness checks fail fast when MySQL is down.
+        "connection_timeout": get_int_env_var("MYSQL_CONNECT_TIMEOUT", default=5),
+    }
+
+
+def get_db_config() -> Dict[str, Any]:
+    """Return the cached database configuration, loading it from the environment if needed."""
+    cached_config = app.config.get("DB_CONFIG")
+    if cached_config is not None:
+        return cached_config
+
+    config = load_db_config_from_env()
+    app.config["DB_CONFIG"] = config
+    return config
+
+
+_CONNECTION_POOL: pooling.MySQLConnectionPool | None = None
+
+
+def reset_connection_pool() -> None:
+    """Clear the cached connection pool (primarily used in tests)."""
+    global _CONNECTION_POOL
+    _CONNECTION_POOL = None
+
+
+def get_connection_pool() -> pooling.MySQLConnectionPool:
+    """Create (or retrieve) the shared MySQL connection pool."""
+    global _CONNECTION_POOL
+    if _CONNECTION_POOL is not None:
+        return _CONNECTION_POOL
+
+    db_config = get_db_config()
+    pool_size = get_int_env_var("MYSQL_POOL_SIZE", default=5)
+
+    try:
+        _CONNECTION_POOL = pooling.MySQLConnectionPool(
+            pool_name="leaderboard_pool",
+            pool_size=pool_size,
+            pool_reset_session=True,
+            **db_config,
+        )
+    except Error as exc:
+        raise RuntimeError(f"❌ Failed to initialise database connection pool: {exc}") from exc
+
+    return _CONNECTION_POOL
+
+
+def get_connection() -> mysql.connector.MySQLConnection:
+    """Obtain a connection from the pool and ensure it is healthy."""
+    try:
+        pool = get_connection_pool()
+    except RuntimeError:
+        # Bubble up the runtime error (missing env vars, pool init failure, etc.).
+        raise
+
+    try:
+        connection = pool.get_connection()
+    except pooling.PoolError as exc:
+        # Pool may have been invalidated; reset and retry once.
+        logger.warning("MySQL connection pool exhausted or invalid. Re-initialising: %s", exc)
+        reset_connection_pool()
+        pool = get_connection_pool()
+        connection = pool.get_connection()
+    except Error as exc:
+        raise RuntimeError(f"❌ Database connection failed: {exc}") from exc
+
+    try:
+        # Ensure the connection is alive; reconnect if needed.
+        connection.ping(reconnect=True, attempts=3, delay=1)
+    except Error as exc:
+        connection.close()
+        reset_connection_pool()
+        raise RuntimeError(f"❌ Database connection failed: {exc}") from exc
+
+    return connection
+
+
+@contextmanager
+def mysql_cursor(*, dictionary: bool = False) -> Iterator[mysql.connector.cursor.MySQLCursor]:
+    """Context manager yielding a cursor that always cleans up resources."""
+    connection: mysql.connector.MySQLConnection | None = None
+    cursor: mysql.connector.cursor.MySQLCursor | None = None
+
+    try:
+        connection = get_connection()
+        cursor = connection.cursor(dictionary=dictionary)
+        yield cursor
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if connection is not None and connection.is_connected():
+            connection.close()
+
+
+def normalise_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert MySQL-specific types (e.g. Decimal, datetime) into JSON serialisable values."""
+    normalised: Dict[str, Any] = {}
+    for key, value in row.items():
+        if isinstance(value, datetime):
+            normalised[key] = value.isoformat()
+        elif isinstance(value, Decimal):
+            normalised[key] = float(value)
+        else:
+            normalised[key] = value
+    return normalised
 
 
 @app.route("/health", methods=["GET"])
@@ -39,14 +158,12 @@ def health():
 @app.route("/readiness", methods=["GET"])
 def readiness():
     try:
-        conn = get_connection()
-        cursor = conn.cursor()
-        cursor.execute("SELECT 1")
-        cursor.close()
-        conn.close()
+        with mysql_cursor() as cursor:
+            cursor.execute("SELECT 1")
         return {"status": "ready"}, 200
-    except Exception as e:
-        return {"status": "not ready", "details": str(e)}, 500
+    except Exception as exc:
+        logger.exception("Readiness check failed")
+        return {"status": "not ready", "details": str(exc)}, 500
 
 
 @app.route("/leaderboard", methods=["GET"])
@@ -70,22 +187,14 @@ def get_leaderboard():
     )
 
     try:
-        conn = get_connection()
-        cursor = conn.cursor(dictionary=True)
-        cursor.execute(query)
-        leaderboard = cursor.fetchall()
-        for row in leaderboard:
-            last_login = row.get("last_login")
-            if isinstance(last_login, datetime):
-                row["last_login"] = last_login.isoformat()
+        with mysql_cursor(dictionary=True) as cursor:
+            cursor.execute(query)
+            rows = cursor.fetchall()
+        leaderboard = [normalise_row(row) for row in rows]
         return jsonify(leaderboard), 200
-    except mysql.connector.Error as e:
-        return jsonify({"error": f"Failed to fetch leaderboard: {e}"}), 500
-    finally:
-        if "cursor" in locals():
-            cursor.close()
-        if "conn" in locals() and conn.is_connected():
-            conn.close()
+    except Exception as exc:
+        logger.exception("Failed to fetch leaderboard")
+        return jsonify({"error": f"Failed to fetch leaderboard: {exc}"}), 500
 
 
 if __name__ == "__main__":

--- a/applications/backend/app/requirements.txt
+++ b/applications/backend/app/requirements.txt
@@ -1,2 +1,3 @@
 flask==3.0.3
 mysql-connector-python==9.0.0
+pytest==8.4.1

--- a/applications/backend/app/tests/test_app.py
+++ b/applications/backend/app/tests/test_app.py
@@ -1,0 +1,113 @@
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import MagicMock
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import app as app_module
+
+
+@pytest.fixture(autouse=True)
+def reset_pool_and_config():
+    """Ensure globals are reset between tests to avoid cross-test state."""
+    app_module.reset_connection_pool()
+    app_module.app.config.pop("DB_CONFIG", None)
+    yield
+    app_module.reset_connection_pool()
+    app_module.app.config.pop("DB_CONFIG", None)
+
+
+@pytest.fixture
+def client():
+    app_module.app.config.update(TESTING=True)
+    with app_module.app.test_client() as test_client:
+        yield test_client
+
+
+def mock_connection(rows=None):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows or []
+    connection = MagicMock()
+    connection.cursor.return_value = cursor
+    connection.is_connected.return_value = True
+    return connection, cursor
+
+
+def test_get_env_var_missing(monkeypatch):
+    monkeypatch.delenv("MISSING_ENV", raising=False)
+    with pytest.raises(RuntimeError) as exc:
+        app_module.get_env_var("MISSING_ENV")
+    assert "MISSING_ENV" in str(exc.value)
+
+
+def test_get_int_env_var_invalid(monkeypatch):
+    monkeypatch.setenv("INVALID_INT", "not-a-number")
+    with pytest.raises(RuntimeError) as exc:
+        app_module.get_int_env_var("INVALID_INT")
+    assert "INVALID_INT" in str(exc.value)
+
+
+def test_normalise_row_handles_datetime_and_decimal():
+    row = {
+        "last_login": datetime(2024, 1, 1, 12, 0, 0),
+        "win_rate": Decimal("56.5"),
+        "gamer_tag": "Vyking",
+    }
+    normalised = app_module.normalise_row(row)
+    assert normalised["last_login"].startswith("2024-01-01T12:00:00")
+    assert normalised["win_rate"] == pytest.approx(56.5)
+    assert normalised["gamer_tag"] == "Vyking"
+
+
+def test_readiness_success(client, monkeypatch):
+    connection, cursor = mock_connection()
+    monkeypatch.setattr(app_module, "get_connection", lambda: connection)
+
+    response = client.get("/readiness")
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "ready"}
+    cursor.execute.assert_called_once_with("SELECT 1")
+    cursor.close.assert_called_once()
+    connection.close.assert_called_once()
+
+
+def test_leaderboard_success(client, monkeypatch):
+    rows = [
+        {
+            "player_id": 1,
+            "gamer_tag": "Vyking",
+            "region": "EU",
+            "player_level": 42,
+            "total_matches": 120,
+            "win_rate": Decimal("55.5"),
+            "avg_session_length": Decimal("32.4"),
+            "favorite_mode": "Solo",
+            "last_login": datetime(2024, 1, 1, 10, 0, 0),
+        }
+    ]
+    connection, cursor = mock_connection(rows)
+    monkeypatch.setattr(app_module, "get_connection", lambda: connection)
+
+    response = client.get("/leaderboard")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert isinstance(payload, list)
+    assert payload[0]["win_rate"] == pytest.approx(55.5)
+    assert payload[0]["last_login"].startswith("2024-01-01T10:00:00")
+    cursor.execute.assert_called_once()
+
+
+def test_leaderboard_failure(client, monkeypatch):
+    def raise_error(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(app_module, "get_connection", raise_error)
+
+    response = client.get("/leaderboard")
+    assert response.status_code == 500
+    assert "boom" in response.get_json()["error"]


### PR DESCRIPTION
## Summary
- introduce configurable MySQL connection pooling, shared cursor helpers, and JSON normalisation in the Flask backend
- add pytest-based coverage for environment helpers, readiness probe, and leaderboard handler using mocked connections
- include pytest in backend requirements for reproducible local test runs

## Testing
- pytest applications/backend/app/tests/test_app.py *(fails: missing flask/mysql-connector packages in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce44e3f7bc832db1d227522230a9c3