### PR TITLE
Fix backend ingress path prefix

### DIFF
--- a/applications/vyking-app/templates/backend/ingress.yaml
+++ b/applications/vyking-app/templates/backend/ingress.yaml
@@ -3,6 +3,11 @@
 {{- $backend := $root.Values.backend -}}
 {{- $name := include "vyking-app.backendFullname" $root -}}
 {{- $namespace := default $root.Release.Namespace $backend.namespace -}}
+{{- $pathPrefix := default "/api" $backend.ingress.path -}}
+{{- $pathType := default "ImplementationSpecific" $backend.ingress.pathType -}}
+{{- $cleanPath := trimSuffix "/" $pathPrefix -}}
+{{- $normalizedPath := ternary "/" $cleanPath (eq $cleanPath "") -}}
+{{- $renderedPath := ternary $normalizedPath (printf "%s(/|$)(.*)" $normalizedPath) (eq $pathType "Prefix") -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -17,8 +22,8 @@ spec:
     - host: {{ $backend.ingress.host }}
       http:
         paths:
-          - path: /api/?(.*)
-            pathType: Prefix
+          - path: {{ $renderedPath }}
+            pathType: {{ $pathType }}
             backend:
               service:
                 name: {{ $name }}

--- a/applications/vyking-app/values.yaml
+++ b/applications/vyking-app/values.yaml
@@ -79,8 +79,11 @@ backend:
   ingress:
     enabled: false
     annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/use-regex: "true"
+      nginx.ingress.kubernetes.io/rewrite-target: /$2
     host: ""
+    path: /api
+    pathType: ImplementationSpecific
   probes:
     liveness:
       path: /health


### PR DESCRIPTION
## Summary
- normalize the backend ingress template to render a legal /api prefix while supporting rewrite-friendly regex when needed
- expose configurable path and pathType defaults in values.yaml and enable nginx regex rewrite annotations for the backend ingress

## Testing
- `helm template vyking-app ./applications/vyking-app --set backend.ingress.enabled=true --set backend.ingress.host=example.com` *(fails: helm not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d113ce6d2c832dbdfd7e6a75bfb7b3